### PR TITLE
Add T1140, T1059.006, T1548.003

### DIFF
--- a/linux/configs/attack-based/defense_evasion/T1140_Deobfuscate_Decode_Data.xml
+++ b/linux/configs/attack-based/defense_evasion/T1140_Deobfuscate_Decode_Data.xml
@@ -1,0 +1,20 @@
+<!--
+  Created: 2024/06/07
+  Modified: 2024/06/08
+
+  Technique: Deobfuscate/Decode Files or Information
+  Reference:
+  - https://attack.mitre.org/techniques/T1140
+  - https://github.com/redcanaryco/atomic-red-team/blob/master/atomics/T1140/T1140.md
+-->
+<Sysmon schemaversion="4.81">
+  <EventFiltering>
+    <RuleGroup name="" groupRelation="or">
+      <ProcessCreate onmatch="include">
+        <Rule name="TechniqueID=T1140,TechniqueName=Deobfuscate/Decode Files or Information" groupRelation="or">
+          <CommandLine condition="contains any">enc;dec;b64;base64;xxd</CommandLine>
+        </Rule>
+      </ProcessCreate>
+    </RuleGroup>
+  </EventFiltering>
+</Sysmon>

--- a/linux/configs/attack-based/execution/T1059.006_Python.xml
+++ b/linux/configs/attack-based/execution/T1059.006_Python.xml
@@ -1,0 +1,22 @@
+<!--
+  Created: 2024/06/07
+  Modified: 2024/06/08
+
+  Technique: Command and Scripting Interpreter: Python
+  Reference:
+  - https://attack.mitre.org/techniques/T1059/006/
+  - https://github.com/redcanaryco/atomic-red-team/blob/master/atomics/T1059.006/T1059.006.md
+-->
+<Sysmon schemaversion="4.81">
+  <EventFiltering>
+    <RuleGroup name="" groupRelation="or">
+      <ProcessCreate onmatch="include">
+        <Rule name="TechniqueID=T1059.006,TechniqueName=Command and Scripting Interpreter: Python" groupRelation="or">
+          <Image condition="contains">python</Image>
+          <Image condition="contains">python2</Image>
+          <Image condition="contains">python3</Image>
+        </Rule>
+      </ProcessCreate>
+    </RuleGroup>
+  </EventFiltering>
+</Sysmon>

--- a/linux/configs/attack-based/privilege_escalation/T1548.003_ElevationControl_Sudo.xml
+++ b/linux/configs/attack-based/privilege_escalation/T1548.003_ElevationControl_Sudo.xml
@@ -1,0 +1,21 @@
+<!--
+  Created: 2024/06/07
+  Modified: 2024/06/08
+
+  Technique: Abuse Elevation Control Mechanism: Sudo and Sudo Caching
+  Reference:
+  - https://attack.mitre.org/techniques/T1548/003/
+  - https://github.com/redcanaryco/atomic-red-team/blob/master/atomics/T1548.003/T1548.003.md
+-->
+<Sysmon schemaversion="4.81">
+  <EventFiltering>
+    <RuleGroup name="" groupRelation="or">
+      <ProcessCreate onmatch="include">
+        <Rule name="TechniqueID=T1548.003,TechniqueName=Abuse Elevation Control Mechanism: Sudo and Sudo Caching" groupRelation="or">
+          <Image condition="end with">/sudo</Image>
+          <Image condition="end with">/su</Image>
+        </Rule>
+      </ProcessCreate>
+    </RuleGroup>
+  </EventFiltering>
+</Sysmon>


### PR DESCRIPTION
Comparing coverage with [auditd](https://github.com/Neo23x0/auditd) this repo looks like the best place to start porting over and maintaining rules as I test them. I'm opening this pull request so that if these additions make sense, they become available here.

- T1140 Deobfuscate/Decode Files or Information
- T1059.006 Command and Scripting Interpreter: Python
- T1548.003 Abuse Elevation Control Mechanism: Sudo and Sudo Caching

If there's a better way to do this, please let me know. 👍